### PR TITLE
ci(workflow): 更新插件发布工作流中的GitHub用户设置

### DIFF
--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -48,8 +48,8 @@ jobs:
           echo "Plugin author: $AUTHOR"
           echo "author=$AUTHOR" >> $GITHUB_OUTPUT
 
-          # GitHub username for repository operations (auto-detect from current repo)
-          GITHUB_USER="${{ github.repository_owner }}"
+          # GitHub organization for repository operations
+          GITHUB_USER="tdcktz"
           echo "GitHub user: $GITHUB_USER"
           echo "github_user=$GITHUB_USER" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
将自动检测的GitHub用户名替换为固定的组织名称tdcktz，以确保发布流程的一致性