### PR TITLE
ci(workflow): 更新插件发布工作流的用户和组织变量

### DIFF
--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -48,10 +48,15 @@ jobs:
           echo "Plugin author: $AUTHOR"
           echo "author=$AUTHOR" >> $GITHUB_OUTPUT
 
-          # GitHub organization for repository operations
-          GITHUB_USER="tdcktz"
+          # GitHub username for repository operations
+          GITHUB_USER="JAVA-LW"
           echo "GitHub user: $GITHUB_USER"
           echo "github_user=$GITHUB_USER" >> $GITHUB_OUTPUT
+          
+          # Organization name for plugin directory
+          ORG_NAME="tdcktz"
+          echo "Organization name: $ORG_NAME"
+          echo "org_name=$ORG_NAME" >> $GITHUB_OUTPUT
 
       - name: Package Plugin
         id: package
@@ -94,8 +99,8 @@ jobs:
           ls -la
 
           # Move the packaged file to the target directory using variables
-          mkdir -p dify-plugins/${{ steps.get_basic_info.outputs.github_user }}/${{ steps.get_basic_info.outputs.plugin_name }}
-          mv "$PACKAGE_NAME" dify-plugins/${{ steps.get_basic_info.outputs.github_user }}/${{ steps.get_basic_info.outputs.plugin_name }}/
+          mkdir -p dify-plugins/${{ steps.get_basic_info.outputs.org_name }}/${{ steps.get_basic_info.outputs.plugin_name }}
+          mv "$PACKAGE_NAME" dify-plugins/${{ steps.get_basic_info.outputs.org_name }}/${{ steps.get_basic_info.outputs.plugin_name }}/
 
           # Enter the target repository directory
           cd dify-plugins


### PR DESCRIPTION
将GitHub用户名从'tdcktz'改为'JAVA-LW'，并添加单独的组织名称变量'tdcktz' 修改插件目录路径以使用新的组织名称变量